### PR TITLE
Added update flag to allow skipping known files when calculating hashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,3 @@ install:
 
 script:
     tox -e $TOX_ENV
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: pip
 env:
     - TOX_ENV=py26
     - TOX_ENV=py27
-    - TOX_ENV=coveralls
 
 install:
     - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: python
+python: 2.7
+cache: pip
+
+env:
+    - TOX_ENV=py26
+    - TOX_ENV=py27
+    - TOX_ENV=coveralls
+
+install:
+    - pip install --upgrade pip
+    - pip install tox
+
+script:
+    tox -e $TOX_ENV
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: 2.7
 cache: pip
 
 env:
-    - TOX_ENV=py26
+    - TOX_ENV=py27
 
 install:
     - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: pip
 
 env:
     - TOX_ENV=py26
-    - TOX_ENV=py27
 
 install:
     - pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from setuptools import setup, find_packages
 
 longdesc = """
-PyBagIt Version 1.5
+PyBagIt Version 1.5.3
 
 This module helps with creating an managing BagIt-compliant packages. It has
 been created to conform to BagIt v0.96.
@@ -51,7 +51,7 @@ easy_install pybagit
 setup(
     name = 'pybagit',
     long_description = longdesc,
-    version = '1.5.2',
+    version = '1.5.3',
     url = 'http://ahankinson.github.io/pybagit',
     author = 'Andrew Hankinson',
     author_email = 'andrew.hankinson@mail.mcgill.ca',

--- a/test/bagupdate.py
+++ b/test/bagupdate.py
@@ -14,8 +14,12 @@ class UpdateTest(unittest.TestCase):
         if os.path.exists(os.path.join(os.getcwd(), 'test', 'invalid_bag')):
             shutil.rmtree(os.path.join(os.getcwd(), 'test', 'invalid_bag'))
 
-    def test_update(self):
-        self.bag.update()
+    def test_full_update(self):
+        self.bag.update(full=True)
+        self.assertEquals(len(self.bag.bag_errors), 0)
+
+    def test_partial_update(self):
+        self.bag.update(full=False)
         self.assertEquals(len(self.bag.bag_errors), 0)
 
     def test_is_valid(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = 
+    py26,
+    py27
+
+skip_missing_interpreters = True
+usedevelop = True
+
+[testenv]
+commands = 
+    pip freeze
+    python setup.py test
+
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+
+commands =
+    pip freeze
+    python setup.py test
+    coveralls
+
+deps =
+    coveralls
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -10,16 +10,3 @@ usedevelop = True
 commands = 
     pip freeze
     python setup.py test
-
-[testenv:coveralls]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-
-commands =
-    pip freeze
-    python setup.py test
-    coveralls
-
-deps =
-    coveralls
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = 
-    py26,
     py27
 
 skip_missing_interpreters = True


### PR DESCRIPTION
It's quite a hefty change but I think a useful one. In addition to the standard workflow of re-checksumming all files on update it is now possible to skip the known files and only checksum the new files.