### PR TITLE
Update version of the specification

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 PyBagIt Version 1.5
 
 This module helps with creating an managing BagIt-compliant packages. It has
-been created to conform to BagIt v0.96.
+been created to conform to BagIt v0.97.
 
 Documentation is available at http://ahankinson.github.io/pybagit. 
 Code hosting is available on GitHub at http://github.com/ahankinson/pybagit/.

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,8 +35,8 @@
 <h1>PyBagIt 1.0 Documentation</h1>
 <p>Project Website: <a href="http://ahankinson.github.io/pybagit">http://ahankinson.github.io/pybagit</a></p>
 <p>Code hosting: <a href="http://github.com/ahankinson/pybagit">http://github.com/ahankinson/pybagit</a></p>
-<p>BagIt 0.96 Spec: <a href="http://www.digitalpreservation.gov/library/resources/tools/docs/bagitspec.pdf">http://www.digitalpreservation.gov/library/resources/tools/docs/bagitspec.pdf</a></p>
-<p>This module simplifies creation and management of BagIt files. Version 1.0 of this module conforms to the BagIt v0.96 specification.</p>
+<p>BagIt 0.97 Spec: <a href="http://www.loc.gov/digitalpreservation/documents/bagitspec.pdf">http://www.loc.gov/digitalpreservation/documents/bagitspec.pdf</a></p>
+<p>This module simplifies creation and management of BagIt files. Version 1.0 of this module conforms to the BagIt v0.97 specification.</p>
 
 <p>This is a "loosely monitored" bag system. The constructor simply specifies a folder to monitor. Files can be added and removed from the data directory at will, and the <code>update()</code> method for that bag will automatically checksum and add all the appropriate files to the manifest files.</p>
 
@@ -111,7 +111,7 @@
 <h3><code>instance.show_bag_info()</code></h3>
 <p>Prints a number of bag properties, e.g.</p>
 <pre>
-Bag Version: 0.96
+Bag Version: 0.97
 Tag File Encoding: utf-8
 Bag Type: Extended
 
@@ -188,9 +188,9 @@ No Errors.
 <h3><code>instance.hash_encoding</code></h3>
 <p><code>sha1</code> or <code>md5</code>. Default is <code>sha1</code>
 <h3><code>instance.bag_major_version</code></h3>
-<p>Returns the major version number as declared in bagit.txt. Any files created by this package will be default to v0.96, so this property would return 0.</p>
+<p>Returns the major version number as declared in bagit.txt. Any files created by this package will be default to v0.97, so this property would return 0.</p>
 <h3><code>instance.bag_minor_version</code></h3>
-<p>Returns the minor version number as declared in bagit.txt. Any files created by this package will be default to v0.96, so this property would return 96.</p>
+<p>Returns the minor version number as declared in bagit.txt. Any files created by this package will be default to v0.97, so this property would return 97.</p>
 <h3><code>instance.tag_file_encoding</code></h3> 
 <p>Returns the tag file encoding as declared in bagit.txt. Any files created by this package will default to utf-8.</p>
 <h3><code>instance.data_directory</code></h3>

--- a/pybagit/bagit.py
+++ b/pybagit/bagit.py
@@ -61,7 +61,7 @@ class BagIt:
         self.extended          = extended  # True if it is an 'extended' bag; False if it is not.
         self.hash_encoding     = u'sha1'  # default hash encoding. Could also be md5. Should always be lowercase.
         self.bag_major_version = 0
-        self.bag_minor_version = 96   # default bagit version. Set to the latest approved version.
+        self.bag_minor_version = 97   # default bagit version. Set to the latest approved version.
         self.tag_file_encoding = u'utf-8'  # default text encoding. always lower case.
         self.data_directory    = None  # path to the bag data directory
         self.bag_directory     = None  # path to the bag directory

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ longdesc = """
 PyBagIt Version 1.5
 
 This module helps with creating an managing BagIt-compliant packages. It has
-been created to conform to BagIt v0.96.
+been created to conform to BagIt v0.97.
 
 Documentation is available at http://ahankinson.github.io/pybagit.
 Code hosting is available on GitHub at http://github.com/ahankinson/pybagit/.


### PR DESCRIPTION
The [current version of the IETF draft](http://tools.ietf.org/html/draft-kunze-bagit) is 0.97.  There have been [no substantial changes](https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-kunze-bagit-11.txt) compared to 0.96.  Thus, if pybagit was conform to 0.96, it still is conform to 0.97.
 