### PR TITLE
Fix tearDown() in test/bagcreate

### DIFF
--- a/test/bagcreate.py
+++ b/test/bagcreate.py
@@ -14,6 +14,8 @@ class CreateTest(unittest.TestCase):
     def tearDown(self):
         if os.path.exists(os.path.join(os.getcwd(), 'test', 'newtestbag')):
             shutil.rmtree(os.path.join(os.getcwd(), 'test', 'newtestbag'))
+        if os.path.exists(os.path.join(os.getcwd(), 'test', 'tëst')):
+            shutil.rmtree(os.path.join(os.getcwd(), 'test', 'tëst'))
 
     def test_minimal_bag_creation(self):
         newbag = BagIt(os.path.join(os.getcwd(), 'test', 'newtestbag'), extended=False)


### PR DESCRIPTION
The test test_unicode_characters_in_bagnam() in test/bagcreate.py creates a test bag named 'tëst', but the tearDown() of the test class fails to remove it.
