### PR TITLE
Allow creation of a bag if the directory already exists.

### DIFF
--- a/bagtest.py
+++ b/bagtest.py
@@ -4,6 +4,7 @@ from test import bagfetch  # comment this out if no network connection
 from test import bagcompress
 from test import bagupdate
 from test import bagcreate
+from test import bagcreateexisting
 from test import bagversion
 
 
@@ -14,6 +15,7 @@ def suite():
     test_suite.addTest(bagcompress.suite())
     test_suite.addTest(bagupdate.suite())
     test_suite.addTest(bagcreate.suite())
+    test_suite.addTest(bagcreateexisting.suite())
     test_suite.addTest(bagversion.suite())
     return test_suite
 

--- a/pybagit/bagit.py
+++ b/pybagit/bagit.py
@@ -398,20 +398,14 @@ class BagIt:
     def _create_bag(self):
         """ Initializes a new bag directory. """
 
-        current_path = os.getcwd()
+        self.bag_directory = os.path.abspath(self._bag)
         try:
-            if os.path.isabs(self._bag):
-                os.mkdir(self._bag)
-            else:
-                os.mkdir(os.path.join(current_path, self._bag))
+            os.mkdir(self.bag_directory)
         except OSError, e:
             raise BagCouldNotBeCreatedError("Bag Could Not Be Created: {0}".format(e))
-            return
         except Exception, e:
-            raise BagError('Could not create directory {0}').format(os.path.join(current_path, self._bag))
-            return
+            raise BagError('Could not create directory {0}').format(self.bag_directory)
 
-        self.bag_directory = os.path.join(current_path, self._bag)
         self.data_directory = os.path.join(self.bag_directory, 'data')
         os.mkdir(self.data_directory)
 

--- a/pybagit/bagit.py
+++ b/pybagit/bagit.py
@@ -31,6 +31,7 @@ import zipfile
 import tarfile
 import sys
 import os
+import errno
 import shutil
 import codecs
 import string
@@ -404,13 +405,18 @@ class BagIt:
         self.bag_directory = os.path.abspath(self._bag)
         try:
             os.mkdir(self.bag_directory)
-        except OSError, e:
-            raise BagCouldNotBeCreatedError("Bag Could Not Be Created: {0}".format(e))
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise BagCouldNotBeCreatedError("Bag Could Not Be Created: {0}".format(e))
         except Exception, e:
             raise BagError('Could not create directory {0}').format(self.bag_directory)
 
         self.data_directory = os.path.join(self.bag_directory, 'data')
-        os.mkdir(self.data_directory)
+        try:
+            os.mkdir(self.data_directory)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
         version_id = u"BagIt-Version: {0}.{1}\n".format(self.bag_major_version,
                                                      self.bag_minor_version)

--- a/pybagit/bagit.py
+++ b/pybagit/bagit.py
@@ -45,7 +45,7 @@ from pybagit.exceptions import *
 
 
 class BagIt:
-    def __init__(self, bag, validate=False, extended=True, fetch=False):
+    def __init__(self, bag, validate=False, extended=True, fetch=False, create=False):
         """ Creates a Bag object. If file doesn't exist, it initializes an
             empty directory with empty files; if it does, it reads in the
             existing files.
@@ -55,6 +55,9 @@ class BagIt:
 
             If fetch is True, it fetches the files from fetch.txt and places
             them in the appropriate directory.
+
+            If create is True, a new bag will be created even if the bag
+            directory exists.
         """
 
         self._bag              = bag  # bag as passed in. Could be either directory or file name, and may not exist.
@@ -84,10 +87,10 @@ class BagIt:
         module_path = os.path.dirname(os.path.abspath(__file__))
         self._path_to_multichecksum = os.path.join(module_path, "multichecksum.py")
 
-        if os.path.exists(self._bag):
-            self._open_bag()
-        else:
+        if create or not os.path.exists(self._bag):
             self._create_bag()
+        else:
+            self._open_bag()
         if validate:
             self.validate()
 

--- a/pybagit/bagit.py
+++ b/pybagit/bagit.py
@@ -84,17 +84,12 @@ class BagIt:
         module_path = os.path.dirname(os.path.abspath(__file__))
         self._path_to_multichecksum = os.path.join(module_path, "multichecksum.py")
 
-        try:
-            if os.path.exists(self._bag):
-                self._open_bag()
-                return
-            else:
-                raise BagDoesNotExistError("Bag does not exist at {0}".format(self._bag))
-        except BagDoesNotExistError:
+        if os.path.exists(self._bag):
+            self._open_bag()
+        else:
             self._create_bag()
-        finally:
-            if validate:
-                self.validate()
+        if validate:
+            self.validate()
 
     def is_valid(self):
         """ Returns True if no validation errors have been reported."""

--- a/test/bagcreateexisting.py
+++ b/test/bagcreateexisting.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+import os.path
+import shutil
+from pybagit.bagit import BagIt
+
+
+class CreateExistingTest(unittest.TestCase):
+    """ Create a bag with already existing data directory.
+    """
+
+    def setUp(self):
+        self.bagdir = os.path.join(os.getcwd(), 'test', 'newtestbag')
+        datadir = os.path.join(self.bagdir, 'data')
+        datafile = os.path.join(os.getcwd(), 'test', 'testbag', 
+                                'data', 'subdir', 'subsubdir', 'angry.jpg')
+        os.mkdir(self.bagdir)
+        os.mkdir(datadir)
+        shutil.copy(datafile, datadir)
+
+    def tearDown(self):
+        if os.path.exists(self.bagdir):
+            shutil.rmtree(self.bagdir)
+
+    def test_bag_creation(self):
+        newbag = BagIt(self.bagdir, create=True)
+        newbag.update()
+        self.assertTrue(os.path.exists(self.bagdir))
+        self.assertTrue(os.path.exists(os.path.join(self.bagdir, 'bagit.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.bagdir, 'manifest-sha1.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.bagdir, 'data')))
+        self.assertTrue(os.path.exists(os.path.join(self.bagdir, 'bag-info.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.bagdir, 'fetch.txt')))
+        self.assertTrue(os.path.exists(os.path.join(self.bagdir, 'tagmanifest-sha1.txt')))
+
+        self.assertTrue(newbag.is_valid())
+        self.assertEquals(newbag.manifest_contents[os.path.join('data', 'angry.jpg')],
+                          u'c5913ae67aa40398f1182e52d2fa2c2e4c08f696')
+
+def suite():
+    test_suite = unittest.makeSuite(CreateExistingTest, 'test')
+    return test_suite


### PR DESCRIPTION
Resolve #7.

This is a minimal version of a possible implementation.  For the moment, it only adds a "create" flag to the constructor, as discussed in the issue, and ignores OSErrors from mkdir if the directory already exists in _create_bag().  It does not check whether any of the meta files (bagit.txt, ...) in the bag directory already exist and boldly overwrites them.  Thanks to the constructor flag, it does not change the behavior of pybagit, unless explicitly requested.

I think, there are three possible ways to proceed from here:
1. Take the PR as it is now.  It does the job and fits at least for my use case.  I care only for using already existing data, but not for meta files.  This works now.
2. Check if any meta file exists in the bag directory and throw an error if this is the case.  This would prevent overwriting existing files.
3. If any meta file exists, read it and adapt the newly created bag accordingly rather then writing this file.

Nr. 3 could become cumbersome and I'm not sure whether there is any real use case for it.

Any opinions?
